### PR TITLE
Add formatting and validation for KH numbers

### DIFF
--- a/lib/jquery.mobilePhoneNumber.js
+++ b/lib/jquery.mobilePhoneNumber.js
@@ -703,18 +703,12 @@
       format: '+... ... ... ...'
     },
     '+855': {
-      country: "KH",
-      format: "+... .. ... ...",
-      min_length: 12,
-      max_length: 13,
-      pattern: /^\+855[1-9]\d{7,8}$/
+      country: 'KH',
+      format: '+... .. ... ...'
     },
     '+8550': {
-      country: "KH",
-      format: "+... (.) .. ... ...",
-      min_length: 13,
-      max_length: 14,
-      pattern: /^\+8550[1-9]\d{7,8}$/
+      country: 'KH',
+      format: '+... (.) .. ... ...'
     },
     '+686': {
       country: 'KI'

--- a/src/jquery.mobilePhoneNumber.coffee
+++ b/src/jquery.mobilePhoneNumber.coffee
@@ -488,17 +488,11 @@ formats =
     country : 'KG',
     format : '+... ... ... ...',
   '+855' :
-    country: "KH",
-    format: "+... .. ... ...",
-    min_length: 12,
-    max_length: 13,
-    pattern: /^\+855[1-9]\d{7,8}$/,
+    country: 'KH',
+    format: '+... .. ... ...',
   '+8550' :
-    country: "KH",
-    format: "+... (.) .. ... ...",
-    min_length: 13,
-    max_length: 14,
-    pattern: /^\+8550[1-9]\d{7,8}$/,
+    country: 'KH',
+    format: '+... (.) .. ... ...',
   '+686' :
     country : 'KI',
   '+269' :

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -202,19 +202,3 @@ describe 'jquery.mobilePhoneNumber', ->
       type $phone, '+32495'
       $phone.val('')
       type $phone, '+1415'
-
-  describe 'mobilePhoneNumber.validate', ->
-    it 'should correctly validate KH the phone numbers', ->
-      $phone = createInput().val('').mobilePhoneNumber()
-      $phone.val("85589481812") # valid KH number
-      assert.equal $phone.mobilePhoneNumber('validate'), true
-      $phone.val("855894818121") # valid long KH number
-      assert.equal $phone.mobilePhoneNumber('validate'), true
-      $phone.val("8558948181211") # invalid KH number (too long)
-      assert.equal $phone.mobilePhoneNumber('validate'), false
-      $phone.val("8558948181") # invalid KH number (too short)
-      assert.equal $phone.mobilePhoneNumber('validate'), false
-      $phone.val("855089481812") # valid KH number (starts with 0)
-      assert.equal $phone.mobilePhoneNumber('validate'), true
-      $phone.val("8550089481812") # invalid KH number (starts with 00)
-      assert.equal $phone.mobilePhoneNumber('validate'), false


### PR DESCRIPTION
This pull request adds better formatting and validation for KH numbers.

It also allows you to add `min_length`, `max_length` and `pattern` to the properties of a countries phone number. These attributes are then used to check if the number is valid 
