### PR TITLE
bump jquery to 3.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -473,9 +473,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "jsbn": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "cake test"
   },
   "dependencies": {
-    "jquery": "^3.3.1"
+    "jquery": "^3.4.1"
   },
   "devDependencies": {
     "cake": "~0.1",


### PR DESCRIPTION
Updated jQuery due to CVE-2019-11358.

Testing: I ran the test suite, and jQuery changelog states that there are no incompatibilities from 3.x to 3.4.