### PR TITLE
force nwmatcher >= 1.4.4 for WS-2018-0589

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -648,10 +648,9 @@
       "dev": true
     },
     "nwmatcher": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
-      "dev": true
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
     },
     "oauth-sign": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
   "scripts": {
     "test": "cake test"
   },
+  "//": "nwmatcher is a dep of jquery; pinning version for security issue; ok to remove when upgrading jquery past 3.4.1",
   "dependencies": {
-    "jquery": "^3.4.1"
+    "jquery": "^3.4.1",
+    "nwmatcher": "^1.4.4"
   },
   "devDependencies": {
     "cake": "~0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery.mobilephonenumber",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A general purpose library for validating and formatting mobile phone numbers.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Fixes regex DoS; unclear if this would actually affect us

confirmed tests still pass